### PR TITLE
various fixes from actually using Lisp RPCQ "in production"

### DIFF
--- a/src-tests/test-rpc.lisp
+++ b/src-tests/test-rpc.lisp
@@ -5,70 +5,65 @@
 (in-package #:rpcq-tests)
 
 
+(defparameter *expected-response* "test-response")
+
+(defun test-method (&key (sleep 1 sleep-p))
+  (when sleep-p
+    (sleep sleep))
+  "test-response")
+
+
 (deftest test-client-server-dialogue ()
-  (let* ((expected-response "test-response")
-         (method-name "test-method")
-         (server-thread
+  (let* ((server-function
            (lambda ()
              (let ((dt (rpcq:make-dispatch-table)))
-               (rpcq:dispatch-table-add-handler dt (constantly expected-response)
-                                                :name method-name)
+               (rpcq:dispatch-table-add-handler dt 'test-method)
                (rpcq:start-server :dispatch-table dt
-                                  :listen-addresses '("inproc://RPCQ-test"))))))
-    ;; spawn the server thread
-    (let ((server-thread (bt:make-thread server-thread)))
-      (unwind-protect
-           (progn
-             (sleep 1)
-             ;; hook up the client
-             (rpcq:with-rpc-client (client "inproc://RPCQ-test")
-               ;; send a communique
-               (let ((server-response (rpcq:rpc-call client method-name)))
-                 (is (string= expected-response server-response)))))
-        ;; kill the server thread
-        (bt:destroy-thread server-thread)))))
+                                  :listen-addresses '("inproc://RPCQ-test")))))
+         (server-thread (bt:make-thread server-function)))
+    (sleep 1)
+    (unwind-protect
+      ;; hook up the client
+      (rpcq:with-rpc-client (client "inproc://RPCQ-test")
+        ;; send a communique
+        (let ((server-response (rpcq:rpc-call client "test-method")))
+          (is (string= *expected-response* server-response))))
+      ;; kill the server thread
+      (bt:destroy-thread server-thread))))
 
 (deftest test-client-timeout ()
-  (let* ((method-name "test-method")
-         (server-thread
+  (let* ((server-function
            (lambda ()
              (let ((dt (rpcq:make-dispatch-table)))
-               (rpcq:dispatch-table-add-handler dt (lambda () (sleep 5))
-                                                :name method-name)
+               (rpcq:dispatch-table-add-handler dt 'test-method)
                (rpcq:start-server :dispatch-table dt
-                                  :listen-addresses '("inproc://RPCQ-test"))))))
-    ;; spawn the server thread
-    (let ((server-thread (bt:make-thread server-thread)))
-      (unwind-protect
-           (progn
-             (sleep 1)
-             ;; hook up the client
-             (rpcq:with-rpc-client (client "inproc://RPCQ-test" :timeout 1)
+                                  :listen-addresses '("inproc://RPCQ-test")))))
+         (server-thread (bt:make-thread server-function)))
+    (sleep 1)
+    (unwind-protect
+         ;; hook up the client
+         (rpcq:with-rpc-client (client "inproc://RPCQ-test" :timeout 1)
                ;; send a communique
                (signals sb-ext:timeout
-                 (rpcq:rpc-call client method-name))))
-        ;; kill the server thread
-        (bt:destroy-thread server-thread)))))
+                 (rpcq:rpc-call client "test-method" :sleep 5)))
+      ;; kill the server thread
+      (bt:destroy-thread server-thread))))
 
 (deftest test-server-timeout ()
-  (let* ((method-name "test-method")
-         (server-thread
+  (let* ((server-function
            (lambda ()
              (let ((dt (rpcq:make-dispatch-table)))
-               (rpcq:dispatch-table-add-handler dt (lambda () (sleep 5))
-                                                :name method-name)
+               (rpcq:dispatch-table-add-handler dt 'test-method)
                (rpcq:start-server :timeout 1
                                   :dispatch-table dt
-                                  :listen-addresses '("inproc://RPCQ-test"))))))
-    ;; spawn the server thread
-    (let ((server-thread (bt:make-thread server-thread)))
-      (unwind-protect
-           (progn
-             (sleep 1)
-             ;; hook up the client
-             (rpcq:with-rpc-client (client "inproc://RPCQ-test")
+                                  :listen-addresses '("inproc://RPCQ-test")))))
+         (server-thread (bt:make-thread server-function)))
+    (sleep 1)
+    (unwind-protect
+         ;; hook up the client
+         (rpcq:with-rpc-client (client "inproc://RPCQ-test")
                ;; send a communique
                (signals rpcq::rpc-error
-                 (rpcq:rpc-call client method-name))))
-        ;; kill the server thread
-        (bt:destroy-thread server-thread)))))
+                 (rpcq:rpc-call client "test-method" :sleep 5)))
+      ;; kill the server thread
+      (bt:destroy-thread server-thread))))

--- a/src/client.lisp
+++ b/src/client.lisp
@@ -64,12 +64,26 @@
                      (rpc-protocol-error-object condition)))))
 
 
+(defun prepare-rpc-call-args (args)
+  (let ((**kwargs (make-hash-table :test #'equal)))
+    (loop :for arg :in args
+          :for rest := args :then (rest rest)
+          :if (typep arg 'keyword)
+            :return  (progn
+                       (loop :for (key val) :on rest :by #'cddr :while val
+                             :do (setf (gethash (sanitize-name key) hash-table) val))
+                       (alexandria:plist-hash-table (list "*args" *args
+                                                          "**kwargs" **kwargs)
+                                                    :test #'equal))
+          :else
+            :collect arg :into *args)))
+
 (defun rpc-call (client call &rest args)
   "Makes a synchronous RPC call, designated by the string method name CALL, over the connection CLIENT.  ARGS is a plist of arguments.  Returns the result of the call directly."
   (let* ((uuid (unicly:uuid-princ-to-string (unicly:make-v4-uuid)))
          (request (make-instance '|RPCRequest|
                                  :|id| uuid
-                                 :|params| (alexandria:plist-hash-table args :test #'equal)
+                                 :|params| (prepare-rpc-call-args args)
                                  :|method| (sanitize-name call)))
          (payload (serialize request))
          (socket (rpc-client-socket client)))

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -62,7 +62,8 @@
 
 By default, a symbol passed in for F will be automatically converted into the name of F used in the dispatch table.  To manually specify a name (or to provide a name for a non-symbol value of F), use the keyword argument :NAME."
   (check-type name string)
-  (alexandria:ensure-function f)
+  (unless (global-function-p f)
+    (warn "The symbol ~S doesn't name a global function." f))
   (setf (gethash (sanitize-name name) dispatch-table) f)
   nil)
 
@@ -153,7 +154,6 @@ DISPATCH-TABLE and LOGGING-STREAM are both required arguments.  TIMEOUT is of ty
           (let (request result reply)
             (multiple-value-bind (identity empty-frame raw-request)
                 (%pull-raw-request receiver)
-              
               (handler-case
                   (progn
                     (setf request (deserialize raw-request))

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -7,7 +7,7 @@
 
 (defun sanitize-name (string-designator)
   "Convert a stringifiable STRING-DESIGNATOR into a snake-case string."
-  (substitute #\_ #\- (string string-designator)))
+  (substitute #\_ #\- (string-downcase (string string-designator))))
 
 (defun str->lisp-keyword (str)
   "Convert a snake-case string into a hyphenated Lisp keyword."

--- a/src/utilities.lisp
+++ b/src/utilities.lisp
@@ -21,3 +21,10 @@
   "Converts a foreign array of unsigned characters to a Lisp vector of such."
   (cffi:foreign-array-to-lisp (pzmq:msg-data msg)
                               `(:array :uint8 ,(pzmq:msg-size msg))))
+
+(defun global-function-p (symbol)
+  "Return true if SYMBOL names a global function. Return false if it doesn't."
+  (check-type symbol symbol)
+  (and (fboundp symbol)
+       (not (macro-function symbol))
+       (not (special-operator-p symbol))))


### PR DESCRIPTION
Some fixes in the Lisp code:

* Recursive serialization of nested RPCQ objects.
* Disable automatic serialization of alists as hashes. ( @_@ )
* Proper deserialization of lists (while leaving strings alone).
* Match python-style `*args, **kwargs` parameter lists when decoding RPC requests.
* Correct typecheck at the top of `dispatch-table-add-handler`.

**NOTE:** I'm not sure what the best way to proceed w/r/t _forming_ RPC requests. I'd also like to give Lisp callers the ability to send *args as well as **kwargs, but Lisp doesn't lend itself to breaking argument lists into those two categories when the argument list length is unknown. One option is to walk the argument list until a keyword is found, and then treat the rest as a plist...?